### PR TITLE
Import gpuCardInstanceRepository in serverService

### DIFF
--- a/backend/src/services/serverService.js
+++ b/backend/src/services/serverService.js
@@ -1,4 +1,5 @@
 const serverRepository = require('../repositories/serverRepository');
+const gpuCardInstanceRepository = require('../repositories/gpuCardInstanceRepository');
 
 const createServer = async (data) => {
   try {


### PR DESCRIPTION
## Summary
- import `gpuCardInstanceRepository` into `serverService` to enable GPU instance lookups

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6895534688888329b698a6d9e1f9d38c