### PR TITLE
Fix undefined prisma reference in card usage service

### DIFF
--- a/backend/src/services/cardUsageService.js
+++ b/backend/src/services/cardUsageService.js
@@ -1,4 +1,6 @@
 const cardUsageRepository = require('../repositories/cardUsageRepository');
+const { PrismaClient } = require('@prisma/client');
+const prisma = new PrismaClient();
 
 const createCardUsage = async (data, tx) => {
   console.log('createCardUsage called with data:', data);


### PR DESCRIPTION
## Summary
- import PrismaClient into card usage service to avoid ReferenceError when deleting card usages

## Testing
- `cd backend && npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689551e8b4188329bc3f413f9a34476b