### PR TITLE
Add Docker-based deployment for frontend and backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,22 +91,39 @@ The project now includes stock management functionality for GPU card models. Thi
 - npm or yarn
 - Docker and Docker Compose
 
-### Database Setup (using Docker Compose)
+### Running the Stack with Docker Compose
 
-1.  Ensure Docker and Docker Compose are installed and running on your system.
-2.  Navigate to the project root directory in your terminal.
-3.  Run the following command to start the PostgreSQL database container:
-    ```bash
-    docker-compose up -d
-    ```
-4.  Apply the Prisma database migrations to set up the schema:
-    ```bash
-    cd backend
-    npx prisma migrate dev --name initial_schema
-    ```
-    *(Note: If you encounter drift issues, you may need to run `npx prisma migrate reset` in the `backend` directory to drop and recreate the database before applying migrations. **This will delete all data in the database.**)*
+1. Ensure Docker and Docker Compose are installed and running on your system.
+2. Copy the example environment files and adjust as needed:
+   ```bash
+   cp backend/.env.example backend/.env
+   cp frontend/.env.example frontend/.env
+   ```
+3. From the project root, build and start all services:
+   ```bash
+   docker compose up -d --build
+   ```
+   The frontend will be available at `http://localhost:5173` and the backend API at `http://localhost:3001`.
+4. Database data is persisted in the `db_data` volume. To reset the database completely, run:
+   ```bash
+   docker compose down -v
+   ```
+5. To apply new Prisma migrations after pulling updates:
+   ```bash
+   docker compose exec backend npx prisma migrate deploy
+   ```
+6. To create a new migration while developing:
+   ```bash
+   docker compose exec backend npx prisma migrate dev --name <migration_name>
+   ```
+7. If the schema drifts or you need to start over, reset the database (this deletes all data):
+   ```bash
+   docker compose exec backend npx prisma migrate reset
+   ```
 
-### Backend Setup and Running
+The following sections describe how to run the backend and frontend without Docker if you prefer a manual setup.
+
+### Backend Setup and Running (without Docker)
 
 1.  Navigate to the `backend` directory in your terminal:
     ```bash
@@ -134,7 +151,7 @@ The project now includes stock management functionality for GPU card models. Thi
     ```
     The backend should start and listen on `http://localhost:3001`.
 
-### Frontend Setup and Running
+### Frontend Setup and Running (without Docker)
 
 1.  Open a new terminal and navigate to the `frontend` directory:
     ```bash

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+npm-debug.log
+.env

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,6 +1,14 @@
-DATABASE_URL="postgresql://user:password@localhost:5432/gpu_console"
-GOOGLE_CLIENT_ID="google-client-id"
-GOOGLE_CLIENT_SECRET="google-client-secret"
-JWT_SECRET="your_jwt_secret"
-ADMIN_EMAIL="admin@example.com"
-ADMIN_PASSWORD="adminpassword"
+# Database connection for Docker Compose
+DATABASE_URL=postgresql://user:password@db:5432/gpu_console
+
+# Google OAuth credentials
+GOOGLE_CLIENT_ID=google-client-id
+GOOGLE_CLIENT_SECRET=google-client-secret
+
+# Secrets
+JWT_SECRET=your_jwt_secret
+YOUR_SESSION_SECRET=replace-with-a-secure-random-string
+
+# Initial admin user
+ADMIN_EMAIL=admin@example.com
+ADMIN_PASSWORD=adminpassword

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY prisma ./prisma
+COPY src ./src
+# Prisma requires DATABASE_URL at build time
+ENV DATABASE_URL="postgresql://user:password@db:5432/gpu_console"
+RUN npx prisma generate
+EXPOSE 3001
+CMD ["sh", "-c", "npx prisma migrate deploy && node src/index.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,5 +13,25 @@ services:
     volumes:
       - db_data:/var/lib/postgresql/data
 
+  backend:
+    build: ./backend
+    restart: always
+    env_file:
+      - backend/.env
+    depends_on:
+      - db
+    ports:
+      - "3001:3001"
+
+  frontend:
+    build: ./frontend
+    restart: always
+    env_file:
+      - frontend/.env
+    depends_on:
+      - backend
+    ports:
+      - "5173:5173"
+
 volumes:
   db_data:

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+npm-debug.log
+.env

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,2 @@
+# Base URL for backend API
+VITE_API_BASE=http://localhost:3001

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+EXPOSE 5173
+CMD ["npm", "run", "dev", "--", "--host"]


### PR DESCRIPTION
## Summary
- containerize backend and frontend with Dockerfiles
- expand docker-compose to run backend, frontend, and PostgreSQL services
- document Docker workflow, env setup, and database reset instructions

## Testing
- `docker-compose config`
- `npm --prefix frontend run lint`
- `npm --prefix backend test` *(fails: Missing script "test")*
- `docker-compose build backend frontend` *(fails: Connection refused to Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_689ab83677e88329b609a8de24bd5c22